### PR TITLE
Update to typst 0.11 and add support for inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,15 @@ description = "Render some typst in browser"
 crate-type = ["cdylib"]
 
 [dependencies]
-typst = { git = "https://github.com/typst/typst.git", tag = "v0.10.0" }
-typst-pdf = { git = "https://github.com/typst/typst.git", tag = "v0.10.0" }
-typst-svg = { git = "https://github.com/typst/typst.git", tag = "v0.10.0" }
-typst-render = { git = "https://github.com/typst/typst.git", tag = "v0.10.0" }
-comemo = "0.3"
+comemo = "0.4.0"
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.37"
 js-sys = "0.3.64"
+typst = "0.11.0"
+typst-pdf = "0.11.0"
+typst-svg = "0.11.0"
+typst-render = "0.11.0"
+serde-wasm-bindgen = "0.6.5"
 
 [profile.release]
 panic = 'abort'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SVG/PDF render some typst text, only got it working with vite, and kind of with 
 # Usage
 
 ```ts
-import init, { addFont, setSource, renderSvgMerged } from '@djakish/render-typst'
+import init, { addFont, addSource, renderSvgMerged } from '@djakish/render-typst'
 import lin_font_r from '../assets/fonts/LinLibertine_R.ttf'
 
 // Load a font
@@ -15,8 +15,8 @@ setInputs({
     "name": "world",
 })
 
-// Set source to the wasm 
-setSource(`#text([Hello #sys.inputs.name!],fill: red)`);
+// Set the main source file
+addSource(`#text([Hello #sys.inputs.name!],fill: red)`, "main.typ")
 
 // Get rendered SVG
 let doc = renderSvgMerged()
@@ -27,7 +27,7 @@ let doc = renderSvgMerged()
 With vite you would need [vite-plugin-wasm](https://www.npmjs.com/package/vite-plugin-wasm) and [vite-plugin-top-level-await](https://www.npmjs.com/package/vite-plugin-top-level-await).
 
 
-# Setting up wtih webpack 
+# Setting up with webpack 
 
 Next config that I got to work.
 ```js
@@ -64,7 +64,7 @@ Component that worked
 <button onClick={async (e) => {
     const typst = (await import("@djakish/render-typst"));
     await typst.addFont("/LinLibertine_R.ttf")
-    typst.setSource(`#text("Hello world!",fill: red)`);
+    typst.addSource(`#text("Hello world!",fill: red)`, "main.typ");
     let doc = typst.renderSvgMerged()
     let preview = document.querySelector<HTMLDivElement('#preview')!;
     preview.innerHTML = doc
@@ -74,7 +74,7 @@ Component that worked
 
 # Building 
 
-You need wasm-pack and rust, and dependecies for them.
+You need wasm-pack and rust, and dependencies for them.
 
 ```sh
 wasm-pack build --target bundler 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@ import lin_font_r from '../assets/fonts/LinLibertine_R.ttf'
 // Load a font
 await addFont(lin_font_r)
 
+// Set input values
+setInputs({
+    "name": "world",
+})
+
 // Set source to the wasm 
-setSource(`#text("Hello world!",fill: red)`);
+setSource(`#text([Hello #sys.inputs.name!],fill: red)`);
 
 // Get rendered SVG
 let doc = renderSvgMerged()


### PR DESCRIPTION
- typst is now officially available on crates.io, therefore I replaced the github links in Cargo.toml
- I've added a method `setInputs`, which allows to pass extra data which will be available as `sys.inputs.YOUR_KEY`
  - It's currently typed as `any`, is this fixable to also expose is at as a hashmap of string -> string?
- I've only tested that the SVG rendering works, with very simple inputs
- Fix #5: I've also noticed that support for multiple source files was not yet implemented. I've added the implementation to this PR, but if you prefer, I can also split it up into 2 PRs.